### PR TITLE
Default to vertical alignment at the top

### DIFF
--- a/_objects.pack.scss
+++ b/_objects.pack.scss
@@ -32,12 +32,14 @@ $inuit-enable-pack--bottom: false !default;
 /**
  * 1. Fill all available space.
  * 2. Cause children to be automatically equally sized.
+ * 3. All items are aligned to the tops of each other.
  */
 .#{$inuit-pack-namespace}pack,
 %#{$inuit-pack-namespace}pack {
     width: 100%; /* [1] */
     display: table;
     table-layout: fixed; /* [2] */
+    vertical-align: top; /* [3] */
 }
 
     /**


### PR DESCRIPTION
Hey @csswizardry / @anselmh,

With `.pack--middle` and `.pack--bottom` being available I'd expected either
1. `.pack` to vertically align items to the tops of each other by default.
2. `.pack--top` to be available.

If this is correct, please find this pull request implementing the former.

Thanks,

Jamie
