### PR TITLE
Prevent ancestor from applying border-spacing.

### DIFF
--- a/_objects.pack.scss
+++ b/_objects.pack.scss
@@ -35,6 +35,7 @@ $inuit-enable-pack--bottom: false !default;
  */
 .#{$inuit-pack-namespace}pack,
 %#{$inuit-pack-namespace}pack {
+    border-spacing: 0;
     width: 100%; /* [1] */
     display: table;
     table-layout: fixed; /* [2] */
@@ -157,16 +158,16 @@ $inuit-enable-pack--bottom: false !default;
     /**
      * Reversed order packs.
      */
-    
+
     .#{$inuit-pack-namespace}pack--rev,
     %#{$inuit-pack-namespace}pack--rev {
         direction: rtl;
-    
+
         > .#{$inuit-pack-namespace}pack__item,
         > %#{$inuit-pack-namespace}pack__item {
             direction: ltr;
         }
-    
+
     }
 
 }


### PR DESCRIPTION
Let's say you use `inuit-pack inuit-pack--small` for a 2 column layout, then within one of those columns you use `inuit-pack` to arrange something else — regardless of how deeply nested the descendant is, it will have the `border-spacing` from the `inuit-pack inuit-pack--small` ancestor applied to it.

This pull request applies a default `border-spacing` of 0 to `inuit-pack` to stop this from happening.
